### PR TITLE
Remove the legacy docker-entrypoint file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,2 +1,0 @@
-/api/manage.py syncdb --noinput
-/usr/local/bin/gunicorn config.wsgi:application -w 2 -b :8000


### PR DESCRIPTION
Django ve Python ile alakalı komutlar barındırıyor. Eskiden kalma olduğunu tahmin ediyorum?